### PR TITLE
is_pbx hiera lookup fails so I set the default to false

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,6 @@ class sudo::params (
 )
 {
   $rulesfile = '/etc/sudoers'
-  $is_pbx = hiera(is_pbx)
+  $is_pbx = hiera(is_pbx, false)
   $sudo_fullaccess_group = $operatingsystem ? { default => 'wheel', Debian => 'adm', Ubuntu => 'admin' }
 }


### PR DESCRIPTION
Got this error and didn't want to have to find a place to stash is_pbx in hiera so I set the default to false in the lookup:

err: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find data item is_pbx in any Hiera data file and no default supplied at /etc/puppet/modules/sudo/manifests/params.pp:9 on node node1
