### PR TITLE
Ability to insert free-text lines to sudoers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,30 @@ Host or array of hosts in this group
 
 Description of this host group
 
+    sudo::line { "Icinga-no-tty":
+      ensure => present, # whether the rule should exist or not (present is the default)
+      line => 'Defaults:icinga !requiretty', # can also be an array of hosts
+      comment => "enable access for icinga without requiring tty",
+    }
+
+### sudo::line
+
+This type manages pre-formatted lines to be inserted to sudoers
+
+**Parameters within sudo::line**
+
+#### `ensure`
+
+Whether the specific line should exist or not (present is the default)
+
+#### `line`
+
+Optional content of the line to be managed
+
+#### `comment`
+
+Optional description which is inserted befor the line
+
     sudo::runas { "whoever":
       ensure => present, # whether the rule should exist or not (present is the default)
       who => 'bob', # can also be an array of users

--- a/manifests/line.pp
+++ b/manifests/line.pp
@@ -1,0 +1,11 @@
+define sudo::line (
+  $line,
+  $ensure = present,
+  $comment = undef,
+) {
+
+  sudo::register{"line_${name}":
+    ensure  => $ensure,
+    content => template('sudo/line.erb'),
+  }
+}

--- a/templates/line.erb
+++ b/templates/line.erb
@@ -1,0 +1,7 @@
+<% if @comment -%>
+#
+# <%= @comment %>
+<% end -%>
+<% if @line -%>
+<%= @line %>
+<% end -%>


### PR DESCRIPTION
For some User specific TTY settings I needed the possibility to insert the respective specs to the suoders.
I got aware that this topic is mentioned in the list of open Issues.
Since I like it more when there is just one module involved for one purpose (and therefore not wanting to use Augeas or other modules for this purpose), I expanded the abstractitptyltd/puppet-sudo module with a simple possibility to insert a line to sudoers - as a simple workaround for this and any future needs.

