### PR TITLE
Fix hiera array merge sorting commands

### DIFF
--- a/templates/rule.erb
+++ b/templates/rule.erb
@@ -2,4 +2,21 @@
 #
 # <%= @comment %>
 <% end -%>
+<%
+if @commands.class == Array
+    tmp = []
+    tmp_last = []
+    @commands.each do |item|
+        if item == "ALL"
+            tmp.unshift(item)
+        elsif item.start_with?("!")
+            tmp_last.push(item)
+        else
+            tmp.push(item)
+        end
+    end
+    tmp += tmp_last
+    @commands = tmp
+end
+-%>
 <%= @who %> <%= @servers.class == Array ? @servers.join(", ") : @servers %> = (<%= @runas.class == Array ? @runas.join(", ") : @runas %>) <% if @nopass == true %>NOPASSWD:<% end %><% if @setenv == true %>SETENV:<% end %> <%= @commands.class == Array ? @commands.join(", ") : @commands %>


### PR DESCRIPTION
Hiera deep merge sorts the command array causing issues if the "ALL" keyword is at the end of the line when we have disallowed commands.
commands"=>["/usr/bin/puppet", "/bin/puppet", "!SHELLS", "!SU", "ALL"]
In this case SHELLS and SU will not be disallowed...
Also making sure the disallowed commands are at the end.

I'm not a ruby programmer, if you feel this code can be improve feel free to do so.